### PR TITLE
Kata 35 part 3 improved

### DIFF
--- a/exercises/35_running_commands_in_shell.md
+++ b/exercises/35_running_commands_in_shell.md
@@ -20,3 +20,7 @@ Visual highlight the lines to be sorted
 
 `q:` will show normal mode history
 `q/` will show search history
+
+You can navigate the history with `j`, `k` or arrow buttons and repeat the command with `Enter`.
+
+To close the history window press `:q<cr>`.


### PR DESCRIPTION
I found the only way to close the history window: `:q<cr>`. Do you know a more effective way?